### PR TITLE
Close file when streaming done

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ente",
   "productName": "ente",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "description": "Desktop client for ente.io",
   "main": "app/main.js",

--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -41,6 +41,7 @@ const getFileStream = async (filePath: string) => {
             offset += bytesRead;
             if (bytesRead === 0) {
                 controller.close();
+                await fs.close(file);
             } else {
                 controller.enqueue(buff);
             }

--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -28,22 +28,27 @@ const getFileStream = async (filePath: string) => {
     let offset = 0;
     const readableStream = new ReadableStream<Uint8Array>({
         async pull(controller) {
-            const buff = new Uint8Array(FILE_STREAM_CHUNK_SIZE);
+            try {
+                const buff = new Uint8Array(FILE_STREAM_CHUNK_SIZE);
 
-            // original types were not working correctly
-            const bytesRead = (await fs.read(
-                file,
-                buff,
-                0,
-                FILE_STREAM_CHUNK_SIZE,
-                offset
-            )) as unknown as number;
-            offset += bytesRead;
-            if (bytesRead === 0) {
-                controller.close();
+                // original types were not working correctly
+                const bytesRead = (await fs.read(
+                    file,
+                    buff,
+                    0,
+                    FILE_STREAM_CHUNK_SIZE,
+                    offset
+                )) as unknown as number;
+                offset += bytesRead;
+                if (bytesRead === 0) {
+                    controller.close();
+                    await fs.close(file);
+                } else {
+                    controller.enqueue(buff);
+                }
+            } catch (e) {
+                logError(e, 'stream pull failed');
                 await fs.close(file);
-            } else {
-                controller.enqueue(buff);
             }
         },
     });


### PR DESCRIPTION
## Description

This is due to Node's limit of max. open files at the same time and we weren't closing the files when done streaming causing the too many open files error.

## Test Plan

- There is a way to measure the number of open file descriptors but can't do it right now since I am on windows (https://stackoverflow.com/questions/31151482/node-js-get-open-file-descriptor-count-development), will do it soon. Tested uploading multiple files and it worked well.