### PR TITLE
fix multiple file with same name overriding existing file issue

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -90,28 +90,26 @@ function setupTrayItem() {
 
 function handleDownloads() {
     mainWindow.webContents.session.on('will-download', (event, item) => {
-        item.setSavePath(getUniqueSavePath(item));
+        item.setSavePath(
+            getUniqueSavePath(item.getFilename(), app.getPath('downloads'))
+        );
     });
 }
 
-function getUniqueSavePath(item: Electron.DownloadItem): string {
+function getUniqueSavePath(filename: string, directory: string): string {
     let n = 0;
     let exists;
     let uniqueFileSavePath;
-    const [filenameWithoutExtension, extension] = splitFilenameAndExtension(
-        item.getFilename()
-    );
+    const [filenameWithoutExtension, extension] =
+        splitFilenameAndExtension(filename);
     do {
         let fileNameWithNumberedSuffix;
         if (n > 0) {
             fileNameWithNumberedSuffix = `${filenameWithoutExtension}(${n}).${extension}`;
         } else {
-            fileNameWithNumberedSuffix = item.getFilename();
+            fileNameWithNumberedSuffix = filename;
         }
-        uniqueFileSavePath = path.join(
-            app.getPath('downloads'),
-            fileNameWithNumberedSuffix
-        );
+        uniqueFileSavePath = path.join(directory, fileNameWithNumberedSuffix);
         exists = existsSync(uniqueFileSavePath);
         n++;
     } while (exists);

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,14 +100,12 @@ function getUniqueSavePath(filename: string, directory: string): string {
     let n = 0;
     let exists;
     let uniqueFileSavePath;
-    const [filenameWithoutExtension, extension] = filename.split('.');
+    const [filenameWithoutExtension, extension] =
+        splitFilenameAndExtension(filename);
     do {
         let fileNameWithNumberedSuffix;
         if (n > 0) {
-            fileNameWithNumberedSuffix = [
-                `${filenameWithoutExtension}(${n})`,
-                extension,
-            ].join('.');
+            fileNameWithNumberedSuffix = `${filenameWithoutExtension}(${n}).${extension}`;
         } else {
             fileNameWithNumberedSuffix = filename;
         }
@@ -116,4 +114,14 @@ function getUniqueSavePath(filename: string, directory: string): string {
         n++;
     } while (exists);
     return uniqueFileSavePath;
+}
+
+function splitFilenameAndExtension(filename: string): [string, string] {
+    const lastDotPosition = filename.lastIndexOf('.');
+    if (lastDotPosition === -1) return [filename, null];
+    else
+        return [
+            filename.slice(0, lastDotPosition),
+            filename.slice(lastDotPosition + 1),
+        ];
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,26 +97,21 @@ function handleDownloads() {
 }
 
 function getUniqueSavePath(filename: string, directory: string): string {
-    let n = 0;
-    let exists;
-    let uniqueFileSavePath;
+    let uniqueFileSavePath = path.join(directory, filename);
     const { name: filenameWithoutExtension, ext: extension } =
         path.parse(filename);
-    do {
-        let fileNameWithNumberedSuffix;
-        if (n > 0) {
-            fileNameWithNumberedSuffix = [
-                `${filenameWithoutExtension}(${n})`,
-                extension,
-            ]
-                .filter((x) => x) // filters out undefined/null values
-                .join('.');
-        } else {
-            fileNameWithNumberedSuffix = filename;
-        }
-        uniqueFileSavePath = path.join(directory, fileNameWithNumberedSuffix);
-        exists = existsSync(uniqueFileSavePath);
+    let n = 0;
+    while (existsSync(uniqueFileSavePath)) {
         n++;
-    } while (exists);
+        // filter need to remove undefined extension from the array
+        // else [`${fileName}`, undefined].join(".") will lead to `${fileName}.` as joined string
+        const fileNameWithNumberedSuffix = [
+            `${filenameWithoutExtension}(${n})`,
+            extension,
+        ]
+            .filter((x) => x) // filters out undefined/null values
+            .join('.');
+        uniqueFileSavePath = path.join(directory, fileNameWithNumberedSuffix);
+    }
     return uniqueFileSavePath;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,12 +100,17 @@ function getUniqueSavePath(filename: string, directory: string): string {
     let n = 0;
     let exists;
     let uniqueFileSavePath;
-    const [filenameWithoutExtension, extension] =
-        splitFilenameAndExtension(filename);
+    const { name: filenameWithoutExtension, ext: extension } =
+        path.parse(filename);
     do {
         let fileNameWithNumberedSuffix;
         if (n > 0) {
-            fileNameWithNumberedSuffix = `${filenameWithoutExtension}(${n}).${extension}`;
+            fileNameWithNumberedSuffix = [
+                `${filenameWithoutExtension}(${n})`,
+                extension,
+            ]
+                .filter((x) => x) // filters out undefined/null values
+                .join('.');
         } else {
             fileNameWithNumberedSuffix = filename;
         }
@@ -114,14 +119,4 @@ function getUniqueSavePath(filename: string, directory: string): string {
         n++;
     } while (exists);
     return uniqueFileSavePath;
-}
-
-function splitFilenameAndExtension(filename: string): [string, string] {
-    const lastDotPosition = filename.lastIndexOf('.');
-    if (lastDotPosition === -1) return [filename, null];
-    else
-        return [
-            filename.slice(0, lastDotPosition),
-            filename.slice(lastDotPosition + 1),
-        ];
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,12 +100,14 @@ function getUniqueSavePath(filename: string, directory: string): string {
     let n = 0;
     let exists;
     let uniqueFileSavePath;
-    const [filenameWithoutExtension, extension] =
-        splitFilenameAndExtension(filename);
+    const [filenameWithoutExtension, extension] = filename.split('.');
     do {
         let fileNameWithNumberedSuffix;
         if (n > 0) {
-            fileNameWithNumberedSuffix = `${filenameWithoutExtension}(${n}).${extension}`;
+            fileNameWithNumberedSuffix = [
+                `${filenameWithoutExtension}(${n})`,
+                extension,
+            ].join('.');
         } else {
             fileNameWithNumberedSuffix = filename;
         }
@@ -114,14 +116,4 @@ function getUniqueSavePath(filename: string, directory: string): string {
         n++;
     } while (exists);
     return uniqueFileSavePath;
-}
-
-function splitFilenameAndExtension(filename: string): [string, string] {
-    const lastDotPosition = filename.lastIndexOf('.');
-    if (lastDotPosition === -1) return [filename, null];
-    else
-        return [
-            filename.slice(0, lastDotPosition),
-            filename.slice(lastDotPosition + 1),
-        ];
 }


### PR DESCRIPTION
## Description

check if the same named file exists, and use numbered suffix to avoid conflict.

## Test Plan

tested locally by downloading the same collection multiple times