### PR TITLE
fix app blocking system restart

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -74,4 +74,6 @@ if (!gotTheLock) {
         handleDownloads(mainWindow);
         addAllowOriginHeader(mainWindow);
     });
+
+    app.on('before-quit', () => setIsAppQuitting(true));
 }

--- a/src/utils/menu.ts
+++ b/src/utils/menu.ts
@@ -121,11 +121,7 @@ export function buildMenuBar(): Menu {
                 { type: 'separator' },
                 {
                     label: 'Quit ente',
-                    accelerator: 'CommandOrControl+Q',
-                    click() {
-                        setIsAppQuitting(true);
-                        app.quit();
-                    },
+                    role: 'quit',
                 },
             ],
         },


### PR DESCRIPTION
## Description

use quit role  with a menu item, so that system can  initiated quit on the app during restarts

## Test Plan

- [ ] tested mac restart is not blocked 
- [ ] checked normal cmd+q quit working as expected
- [ ] quit from menu option is working 
- [ ] quit from dock icon also working as expected
