### PR TITLE
Remove out of date user contributed ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ If you are running into issues with this app, please drop a mail to [support@ent
 
 - [Latest Release](https://github.com/ente-io/bhari-frame/releases/latest)
 
-*User contributed ports*
-
-- [AUR](https://aur.archlinux.org/packages/ente-desktop-appimage):
-  `yay -S ente-desktop-appimage`
 
 ## Building from source
 


### PR DESCRIPTION
As nice it is to have user contributed ports, the problem is that they're getting outdated. This one is already a few versions behind our latest release, and we don't have way to update the port so that it's up to date.

Thus removing it from the README so that we're not accidentally suggesting people to install outdated versions with bugs and/or missing features.
