### PR TITLE
Manual update download

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "electron-updater": "^4.3.8",
     "get-folder-size": "^2.0.1",
     "next-electron-server": "file:./thirdparty/next-electron-server",
+    "node-fetch": "^3.2.10",
     "node-stream-zip": "^1.15.0",
     "promise-fs": "^2.1.1",
     "semver-compare": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@sentry/cli": "^1.68.0",
     "@types/auto-launch": "^5.0.2",
     "@types/get-folder-size": "^2.0.0",
+    "@types/node-fetch": "^2.6.2",
     "@types/semver-compare": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
@@ -98,7 +99,7 @@
     "electron-updater": "^4.3.8",
     "get-folder-size": "^2.0.1",
     "next-electron-server": "file:./thirdparty/next-electron-server",
-    "node-fetch": "^3.2.10",
+    "node-fetch": "^2.6.7",
     "node-stream-zip": "^1.15.0",
     "promise-fs": "^2.1.1",
     "semver-compare": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@sentry/cli": "^1.68.0",
     "@types/auto-launch": "^5.0.2",
     "@types/get-folder-size": "^2.0.0",
+    "@types/semver-compare": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "concurrently": "^7.0.0",
@@ -98,7 +99,8 @@
     "get-folder-size": "^2.0.1",
     "next-electron-server": "file:./thirdparty/next-electron-server",
     "node-stream-zip": "^1.15.0",
-    "promise-fs": "^2.1.1"
+    "promise-fs": "^2.1.1",
+    "semver-compare": "^1.0.0"
   },
   "standard": {
     "parser": "babel-eslint"

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -10,11 +10,16 @@ export const reloadWindow = () => {
     ipcRenderer.send('reload-window');
 };
 
-export const registerUpdateEventListener = (showUpdateDialog: () => void) => {
+export const registerUpdateEventListener = (
+    showUpdateDialog: (updateInfo: { uploadDownloaded: boolean }) => void
+) => {
     ipcRenderer.removeAllListeners('show-update-dialog');
-    ipcRenderer.on('show-update-dialog', () => {
-        showUpdateDialog();
-    });
+    ipcRenderer.on(
+        'show-update-dialog',
+        (_, updateInfo: { uploadDownloaded: boolean }) => {
+            showUpdateDialog(updateInfo);
+        }
+    );
 };
 
 export const updateAndRestart = () => {

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -23,3 +23,7 @@ export const registerUpdateEventListener = (
 export const updateAndRestart = () => {
     ipcRenderer.send('update-and-restart');
 };
+
+export const skipAppVersion = (version: string) => {
+    ipcRenderer.send('skip-app-version', version);
+};

--- a/src/api/system.ts
+++ b/src/api/system.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron';
+import { AppUpdateInfo } from '../types';
 
 export const sendNotification = (content: string) => {
     ipcRenderer.send('send-notification', content);
@@ -11,15 +12,12 @@ export const reloadWindow = () => {
 };
 
 export const registerUpdateEventListener = (
-    showUpdateDialog: (updateInfo: { uploadDownloaded: boolean }) => void
+    showUpdateDialog: (updateInfo: AppUpdateInfo) => void
 ) => {
     ipcRenderer.removeAllListeners('show-update-dialog');
-    ipcRenderer.on(
-        'show-update-dialog',
-        (_, updateInfo: { uploadDownloaded: boolean }) => {
-            showUpdateDialog(updateInfo);
-        }
-    );
+    ipcRenderer.on('show-update-dialog', (_, updateInfo: AppUpdateInfo) => {
+        showUpdateDialog(updateInfo);
+    });
 };
 
 export const updateAndRestart = () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import { initWatcher } from './services/chokidar';
 import { addAllowOriginHeader } from './utils/cors';
 import {
     setupTrayItem,
-    handleUpdates,
     handleDownloads,
     setupMacWindowOnDockIconClick,
     setupMainMenu,
@@ -13,6 +12,7 @@ import {
     setupNextElectronServe,
     enableSharedArrayBufferSupport,
     handleDockIconHideOnAutoLaunch,
+    handleUpdates,
 } from './utils/main';
 import { initSentry } from './services/sentry';
 import { setupLogging } from './utils/logging';
@@ -72,7 +72,7 @@ if (!gotTheLock) {
         initSentry();
         setupMainMenu();
         setupIpcComs(tray, mainWindow, watcher);
-        handleUpdates(mainWindow, tray);
+        handleUpdates(mainWindow);
         handleDownloads(mainWindow);
         addAllowOriginHeader(mainWindow);
     });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,6 +4,7 @@ import {
     sendNotification,
     showOnTray,
     updateAndRestart,
+    skipAppVersion,
 } from './api/system';
 import {
     showUploadDirsDialog,
@@ -90,4 +91,5 @@ windowObject['ElectronAPIs'] = {
     openLogDirectory,
     registerUpdateEventListener,
     updateAndRestart,
+    skipAppVersion,
 };

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -3,19 +3,39 @@ import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import { setIsAppQuitting, setIsUpdateAvailable } from '../main';
 import { buildContextMenu } from '../utils/menu';
+import { showUpdateDialog } from '../utils/appUpdate';
+
+const LATEST_SUPPORTED_AUTO_UPDATE_VERSION = '1.6.12';
 
 class AppUpdater {
+    updateDownloaded: boolean;
     constructor() {
         autoUpdater.logger = log;
+        autoUpdater.autoDownload = false;
+    }
+
+    getUpdateDownloaded() {
+        return this.updateDownloaded;
     }
 
     async checkForUpdate(tray: Tray, mainWindow: BrowserWindow) {
-        await autoUpdater.checkForUpdatesAndNotify();
-        autoUpdater.on('update-downloaded', () => {
+        const updateCheckResult = await autoUpdater.checkForUpdatesAndNotify();
+        log.info(updateCheckResult);
+        if (
+            updateCheckResult.updateInfo.version >
+            LATEST_SUPPORTED_AUTO_UPDATE_VERSION
+        ) {
+            this.updateDownloaded = false;
             showUpdateDialog(mainWindow);
-            setIsUpdateAvailable(true);
-            tray.setContextMenu(buildContextMenu(mainWindow));
-        });
+        } else {
+            autoUpdater.downloadUpdate();
+            autoUpdater.on('update-downloaded', () => {
+                this.updateDownloaded = true;
+                showUpdateDialog(mainWindow);
+                setIsUpdateAvailable(true);
+                tray.setContextMenu(buildContextMenu(mainWindow));
+            });
+        }
     }
 
     updateAndRestart = () => {
@@ -25,7 +45,3 @@ class AppUpdater {
 }
 
 export default new AppUpdater();
-
-export const showUpdateDialog = (mainWindow: BrowserWindow): void => {
-    mainWindow.webContents.send('show-update-dialog');
-};

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -20,7 +20,7 @@ export async function checkForUpdateAndNotify(mainWindow: BrowserWindow) {
     try {
         log.debug('checkForUpdateAndNotify called');
         const updateCheckResult = await autoUpdater.checkForUpdates();
-        log.debug(updateCheckResult);
+        log.debug('update version', updateCheckResult.updateInfo.version);
         if (
             semVerCmp(updateCheckResult.updateInfo.version, app.getVersion()) <=
             0

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -76,10 +76,14 @@ export function skipAppVersion(version: string) {
 }
 
 async function getVersionWithKeyChange() {
-    const keyChangeVersion = (
-        await fetch('https://ente.io/desktop-key-change-version')
-    ).json() as GetKeyChangeVersionResponse;
-    return keyChangeVersion.version;
+    try {
+        const keyChangeVersion = (
+            await fetch('https://ente.io/desktop-key-change-version')
+        ).json() as GetKeyChangeVersionResponse;
+        return keyChangeVersion.version;
+    } catch (e) {
+        return undefined;
+    }
 }
 
 function showUpdateDialog(

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -17,7 +17,7 @@ class AppUpdater {
 
     async checkForUpdate(tray: Tray, mainWindow: BrowserWindow) {
         log.debug('checkForUpdate');
-        const updateCheckResult = await autoUpdater.checkForUpdatesAndNotify();
+        const updateCheckResult = await autoUpdater.checkForUpdates();
         log.debug(updateCheckResult);
         if (
             semVerCmp(updateCheckResult.updateInfo.version, app.getVersion()) >

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -37,6 +37,10 @@ class AppUpdater {
                 autoUpdater.on('update-downloaded', () => {
                     showUpdateDialog(mainWindow, { autoUpdatable: true });
                 });
+                autoUpdater.on('error', (error) => {
+                    log.error(error);
+                    showUpdateDialog(mainWindow, { autoUpdatable: false });
+                });
             }
             setIsUpdateAvailable(true);
             tray.setContextMenu(buildContextMenu(mainWindow));

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -6,6 +6,7 @@ import semVerCmp from 'semver-compare';
 import { AppUpdateInfo, GetKeyChangeVersionResponse } from '../types';
 import { getSkipAppVersion, setSkipAppVersion } from './userPreference';
 import fetch from 'node-fetch';
+import { isPlatformMac } from '../utils/main';
 
 export function setupAutoUpdater() {
     autoUpdater.logger = log;
@@ -32,6 +33,7 @@ export async function checkForUpdateAndNotify(mainWindow: BrowserWindow) {
         const versionWithKeyChange = await getVersionWithKeyChange();
         if (
             versionWithKeyChange &&
+            isPlatformMac() &&
             semVerCmp(
                 updateCheckResult.updateInfo.version,
                 versionWithKeyChange

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -49,11 +49,11 @@ class AppUpdater {
     };
 }
 
+export default new AppUpdater();
+
 function showUpdateDialog(
     mainWindow: BrowserWindow,
     updateInfo: AppUpdateInfo
 ) {
     mainWindow.webContents.send('show-update-dialog', updateInfo);
 }
-
-export default new AppUpdater();

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -4,11 +4,12 @@ import log from 'electron-log';
 import { setIsAppQuitting, setIsUpdateAvailable } from '../main';
 import { buildContextMenu } from '../utils/menu';
 import semVerCmp from 'semver-compare';
+import { AppUpdateInfo } from '../types';
 
 const LATEST_SUPPORTED_AUTO_UPDATE_VERSION = '1.6.12';
 
 class AppUpdater {
-    updateDownloaded: boolean;
+    autoUpdatable: boolean;
     constructor() {
         autoUpdater.logger = log;
         autoUpdater.autoDownload = false;
@@ -29,14 +30,14 @@ class AppUpdater {
                     LATEST_SUPPORTED_AUTO_UPDATE_VERSION
                 ) > 0
             ) {
-                log.debug('update not supported');
-                this.updateDownloaded = false;
+                log.debug('auto update not supported');
+                this.autoUpdatable = false;
                 this.showUpdateDialog(mainWindow);
             } else {
-                log.debug('update supported');
+                log.debug('auto update supported');
                 autoUpdater.downloadUpdate();
                 autoUpdater.on('update-downloaded', () => {
-                    this.updateDownloaded = true;
+                    this.autoUpdatable = true;
                     this.showUpdateDialog(mainWindow);
                 });
             }
@@ -52,8 +53,8 @@ class AppUpdater {
 
     showUpdateDialog = (mainWindow: BrowserWindow) => {
         mainWindow.webContents.send('show-update-dialog', {
-            updateDownloaded: this.updateDownloaded,
-        });
+            autoUpdatable: this.autoUpdatable,
+        } as AppUpdateInfo);
     };
 }
 

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -14,7 +14,7 @@ export function setupAutoUpdater() {
 }
 
 export async function checkForUpdateAndNotify(mainWindow: BrowserWindow) {
-    log.debug('checkForUpdate');
+    log.debug('checkForUpdateAndNotify called');
     const updateCheckResult = await autoUpdater.checkForUpdates();
     log.debug(updateCheckResult);
     if (semVerCmp(updateCheckResult.updateInfo.version, app.getVersion()) > 0) {
@@ -39,13 +39,13 @@ export async function checkForUpdateAndNotify(mainWindow: BrowserWindow) {
                 versionWithKeyChange
             ) > 0
         ) {
-            log.debug('auto update not supported');
+            log.debug('auto update not possible due to key change');
             showUpdateDialog(mainWindow, {
                 autoUpdatable: false,
                 version: updateCheckResult.updateInfo.version,
             });
         } else {
-            log.debug('auto update supported');
+            log.debug('attempting auto update');
             autoUpdater.downloadUpdate();
             autoUpdater.on('update-downloaded', () => {
                 showUpdateDialog(mainWindow, {
@@ -54,6 +54,7 @@ export async function checkForUpdateAndNotify(mainWindow: BrowserWindow) {
                 });
             });
             autoUpdater.on('error', (error) => {
+                log.debug('auto update failed');
                 log.error(error);
                 showUpdateDialog(mainWindow, {
                     autoUpdatable: false,

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -3,6 +3,7 @@ import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import { setIsAppQuitting, setIsUpdateAvailable } from '../main';
 import { buildContextMenu } from '../utils/menu';
+import semVerCmp from 'semver-compare';
 
 const LATEST_SUPPORTED_AUTO_UPDATE_VERSION = '1.6.12';
 
@@ -17,8 +18,10 @@ class AppUpdater {
         const updateCheckResult = await autoUpdater.checkForUpdatesAndNotify();
         log.info(updateCheckResult);
         if (
-            updateCheckResult.updateInfo.version >
-            LATEST_SUPPORTED_AUTO_UPDATE_VERSION
+            semVerCmp(
+                updateCheckResult.updateInfo.version,
+                LATEST_SUPPORTED_AUTO_UPDATE_VERSION
+            ) > 0
         ) {
             this.updateDownloaded = false;
             this.showUpdateDialog(mainWindow);

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -1,80 +1,76 @@
-import { app, BrowserWindow, Tray } from 'electron';
+import { app, BrowserWindow } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import { setIsAppQuitting, setIsUpdateAvailable } from '../main';
-import { buildContextMenu } from '../utils/menu';
 import semVerCmp from 'semver-compare';
 import { AppUpdateInfo, GetKeyChangeVersionResponse } from '../types';
 import { getSkipAppVersion, setSkipAppVersion } from './userPreference';
 import fetch from 'node-fetch';
-class AppUpdater {
-    constructor() {
-        autoUpdater.logger = log;
-        autoUpdater.autoDownload = false;
-    }
 
-    async checkForUpdate(tray: Tray, mainWindow: BrowserWindow) {
-        log.debug('checkForUpdate');
-        const updateCheckResult = await autoUpdater.checkForUpdates();
-        log.debug(updateCheckResult);
+export function setupAutoUpdater() {
+    autoUpdater.logger = log;
+    autoUpdater.autoDownload = false;
+}
+
+export async function checkForUpdateAndNotify(mainWindow: BrowserWindow) {
+    log.debug('checkForUpdate');
+    const updateCheckResult = await autoUpdater.checkForUpdates();
+    log.debug(updateCheckResult);
+    if (semVerCmp(updateCheckResult.updateInfo.version, app.getVersion()) > 0) {
+        log.debug('update available');
+        const skipAppVersion = getSkipAppVersion();
         if (
-            semVerCmp(updateCheckResult.updateInfo.version, app.getVersion()) >
-            0
+            skipAppVersion &&
+            updateCheckResult.updateInfo.version === skipAppVersion
         ) {
-            log.debug('update available');
-            const skipAppVersion = getSkipAppVersion();
-            if (
-                skipAppVersion &&
-                updateCheckResult.updateInfo.version === skipAppVersion
-            ) {
-                log.info(
-                    'user chose to skip version ',
-                    updateCheckResult.updateInfo.version
-                );
-                return;
-            }
-            const versionWithKeyChange = await getVersionWithKeyChange();
-            if (
-                versionWithKeyChange &&
-                semVerCmp(
-                    updateCheckResult.updateInfo.version,
-                    versionWithKeyChange
-                ) > 0
-            ) {
-                log.debug('auto update not supported');
+            log.info(
+                'user chose to skip version ',
+                updateCheckResult.updateInfo.version
+            );
+            return;
+        }
+        const versionWithKeyChange = await getVersionWithKeyChange();
+        if (
+            versionWithKeyChange &&
+            semVerCmp(
+                updateCheckResult.updateInfo.version,
+                versionWithKeyChange
+            ) > 0
+        ) {
+            log.debug('auto update not supported');
+            showUpdateDialog(mainWindow, {
+                autoUpdatable: false,
+                version: updateCheckResult.updateInfo.version,
+            });
+        } else {
+            log.debug('auto update supported');
+            autoUpdater.downloadUpdate();
+            autoUpdater.on('update-downloaded', () => {
+                showUpdateDialog(mainWindow, {
+                    autoUpdatable: true,
+                    version: updateCheckResult.updateInfo.version,
+                });
+            });
+            autoUpdater.on('error', (error) => {
+                log.error(error);
                 showUpdateDialog(mainWindow, {
                     autoUpdatable: false,
                     version: updateCheckResult.updateInfo.version,
                 });
-            } else {
-                log.debug('auto update supported');
-                autoUpdater.downloadUpdate();
-                autoUpdater.on('update-downloaded', () => {
-                    showUpdateDialog(mainWindow, {
-                        autoUpdatable: true,
-                        version: updateCheckResult.updateInfo.version,
-                    });
-                });
-                autoUpdater.on('error', (error) => {
-                    log.error(error);
-                    showUpdateDialog(mainWindow, {
-                        autoUpdatable: false,
-                        version: updateCheckResult.updateInfo.version,
-                    });
-                });
-            }
-            setIsUpdateAvailable(true);
-            tray.setContextMenu(buildContextMenu(mainWindow));
+            });
         }
+        setIsUpdateAvailable(true);
     }
-
-    updateAndRestart = () => {
-        setIsAppQuitting(true);
-        autoUpdater.quitAndInstall();
-    };
 }
 
-export default new AppUpdater();
+export function updateAndRestart() {
+    setIsAppQuitting(true);
+    autoUpdater.quitAndInstall();
+}
+
+export function skipAppVersion(version: string) {
+    setSkipAppVersion(version);
+}
 
 async function getVersionWithKeyChange() {
     const keyChangeVersion = (
@@ -88,8 +84,4 @@ function showUpdateDialog(
     updateInfo: AppUpdateInfo
 ) {
     mainWindow.webContents.send('show-update-dialog', updateInfo);
-}
-
-export function skipAppVersion(version: string) {
-    setSkipAppVersion(version);
 }

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -9,7 +9,6 @@ import { AppUpdateInfo } from '../types';
 const LATEST_SUPPORTED_AUTO_UPDATE_VERSION = '1.6.12';
 
 class AppUpdater {
-    autoUpdatable: boolean;
     constructor() {
         autoUpdater.logger = log;
         autoUpdater.autoDownload = false;
@@ -31,14 +30,12 @@ class AppUpdater {
                 ) > 0
             ) {
                 log.debug('auto update not supported');
-                this.autoUpdatable = false;
-                this.showUpdateDialog(mainWindow);
+                showUpdateDialog(mainWindow, { autoUpdatable: false });
             } else {
                 log.debug('auto update supported');
                 autoUpdater.downloadUpdate();
                 autoUpdater.on('update-downloaded', () => {
-                    this.autoUpdatable = true;
-                    this.showUpdateDialog(mainWindow);
+                    showUpdateDialog(mainWindow, { autoUpdatable: true });
                 });
             }
             setIsUpdateAvailable(true);
@@ -50,12 +47,13 @@ class AppUpdater {
         setIsAppQuitting(true);
         autoUpdater.quitAndInstall();
     };
+}
 
-    showUpdateDialog = (mainWindow: BrowserWindow) => {
-        mainWindow.webContents.send('show-update-dialog', {
-            autoUpdatable: this.autoUpdatable,
-        } as AppUpdateInfo);
-    };
+function showUpdateDialog(
+    mainWindow: BrowserWindow,
+    updateInfo: AppUpdateInfo
+) {
+    mainWindow.webContents.send('show-update-dialog', updateInfo);
 }
 
 export default new AppUpdater();

--- a/src/services/userPreference.ts
+++ b/src/services/userPreference.ts
@@ -1,10 +1,16 @@
 import { userPreferencesStore } from '../stores/userPreferences.store';
 
 export function getHideDockIconPreference() {
-    const shouldHideDockIcon = userPreferencesStore.get('hideDockIcon');
-    return shouldHideDockIcon;
+    return userPreferencesStore.get('hideDockIcon');
 }
 
 export function setHideDockIconPreference(shouldHideDockIcon: boolean) {
     userPreferencesStore.set('hideDockIcon', shouldHideDockIcon);
+}
+
+export function getSkipAppVersion() {
+    return userPreferencesStore.get('skipAppVersion');
+}
+export function setSkipAppVersion(version: string) {
+    userPreferencesStore.set('skipAppVersion', version);
 }

--- a/src/stores/userPreferences.store.ts
+++ b/src/stores/userPreferences.store.ts
@@ -5,6 +5,9 @@ const userPreferencesSchema: Schema<UserPreferencesType> = {
     hideDockIcon: {
         type: 'boolean',
     },
+    skipAppVersion: {
+        type: 'string',
+    },
 };
 
 export const userPreferencesStore = new Store({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,6 +64,6 @@ export interface AppUpdateInfo {
     version: string;
 }
 
-export interface GetKeyChangeVersionResponse {
-    version?: string;
+export interface GetFeatureFlagResponse {
+    desktopCutoffVersion?: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,8 +56,10 @@ export interface SafeStorageStoreType {
 
 export interface UserPreferencesType {
     hideDockIcon: boolean;
+    skipAppVersion: string;
 }
 
 export interface AppUpdateInfo {
     autoUpdatable: boolean;
+    version: string;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,3 +63,7 @@ export interface AppUpdateInfo {
     autoUpdatable: boolean;
     version: string;
 }
+
+export interface GetKeyChangeVersionResponse {
+    version?: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,3 +57,7 @@ export interface SafeStorageStoreType {
 export interface UserPreferencesType {
     hideDockIcon: boolean;
 }
+
+export interface AppUpdateInfo {
+    autoUpdatable: boolean;
+}

--- a/src/utils/ipcComms.ts
+++ b/src/utils/ipcComms.ts
@@ -15,7 +15,7 @@ import chokidar from 'chokidar';
 import path from 'path';
 import { getDirFilePaths } from '../services/fs';
 import { convertHEIC } from '../services/heicConvertor';
-import appUpdater, { skipAppVersion } from '../services/appUpdater';
+import { skipAppVersion, updateAndRestart } from '../services/appUpdater';
 
 export default function setupIpcComs(
     tray: Tray,
@@ -109,7 +109,7 @@ export default function setupIpcComs(
     });
 
     ipcMain.on('update-and-restart', () => {
-        appUpdater.updateAndRestart();
+        updateAndRestart();
     });
     ipcMain.on('skip-app-version', (_, version) => {
         skipAppVersion(version);

--- a/src/utils/ipcComms.ts
+++ b/src/utils/ipcComms.ts
@@ -15,7 +15,7 @@ import chokidar from 'chokidar';
 import path from 'path';
 import { getDirFilePaths } from '../services/fs';
 import { convertHEIC } from '../services/heicConvertor';
-import appUpdater from '../services/appUpdater';
+import appUpdater, { skipAppVersion } from '../services/appUpdater';
 
 export default function setupIpcComs(
     tray: Tray,
@@ -110,5 +110,8 @@ export default function setupIpcComs(
 
     ipcMain.on('update-and-restart', () => {
         appUpdater.updateAndRestart();
+    });
+    ipcMain.on('skip-app-version', (_, version) => {
+        skipAppVersion(version);
     });
 }

--- a/src/utils/main.ts
+++ b/src/utils/main.ts
@@ -4,18 +4,21 @@ import electronReload from 'electron-reload';
 import serveNextAt from 'next-electron-server';
 import path from 'path';
 import { existsSync } from 'promise-fs';
-import appUpdater from '../services/appUpdater';
 import { isDev } from './common';
 import { buildContextMenu, buildMenuBar } from './menu';
 import autoLauncher from '../services/autoLauncher';
 import { getHideDockIconPreference } from '../services/userPreference';
+import {
+    checkForUpdateAndNotify,
+    setupAutoUpdater,
+} from '../services/appUpdater';
 
-export function handleUpdates(mainWindow: BrowserWindow, tray: Tray) {
+export function handleUpdates(mainWindow: BrowserWindow) {
     if (!isDev) {
-        appUpdater.checkForUpdate(tray, mainWindow);
+        setupAutoUpdater();
+        checkForUpdateAndNotify(mainWindow);
     }
 }
-
 export function setupTrayItem(mainWindow: BrowserWindow) {
     const trayImgPath = isDev
         ? 'build/taskbar-icon.png'

--- a/src/utils/menu.ts
+++ b/src/utils/menu.ts
@@ -12,7 +12,7 @@ import {
 import { isUpdateAvailable, setIsAppQuitting } from '../main';
 import autoLauncher from '../services/autoLauncher';
 import { isPlatformMac } from './main';
-import { showUpdateDialog } from '../services/appUpdater';
+import appUpdater from '../services/appUpdater';
 
 export function buildContextMenu(
     mainWindow: BrowserWindow,
@@ -29,7 +29,7 @@ export function buildContextMenu(
             ? [
                   {
                       label: 'Update available',
-                      click: () => showUpdateDialog(mainWindow),
+                      click: () => appUpdater.showUpdateDialog(mainWindow),
                   },
               ]
             : []),

--- a/src/utils/menu.ts
+++ b/src/utils/menu.ts
@@ -9,10 +9,9 @@ import {
     getHideDockIconPreference,
     setHideDockIconPreference,
 } from '../services/userPreference';
-import { isUpdateAvailable, setIsAppQuitting } from '../main';
+import { setIsAppQuitting } from '../main';
 import autoLauncher from '../services/autoLauncher';
 import { isPlatformMac } from './main';
-import appUpdater from '../services/appUpdater';
 
 export function buildContextMenu(
     mainWindow: BrowserWindow,
@@ -25,15 +24,6 @@ export function buildContextMenu(
         paused,
     } = args;
     const contextMenu = Menu.buildFromTemplate([
-        ...(isUpdateAvailable()
-            ? [
-                  {
-                      label: 'Update available',
-                      click: () => appUpdater.showUpdateDialog(mainWindow),
-                  },
-              ]
-            : []),
-        { type: 'separator' },
         ...(exportProgress
             ? [
                   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,6 +1180,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
+
 date-fns@^2.16.1:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
@@ -1770,6 +1775,14 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -1841,6 +1854,13 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
@@ -2790,12 +2810,26 @@ node-addon-api@^1.6.3:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.2.10:
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.10.tgz#e8347f94b54ae18b57c9c049ef641cef398a85c8"
+  integrity sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-stream-zip@^1.15.0:
   version "1.15.0"
@@ -3986,6 +4020,11 @@ verror@^1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,6 +312,14 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
+"@types/node-fetch@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "18.0.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.3.tgz#463fc47f13ec0688a33aec75d078a0541a447199"
@@ -1180,11 +1188,6 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-uri-to-buffer@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
-  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
-
 date-fns@^2.16.1:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
@@ -1775,14 +1778,6 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
-  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
-  dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
-
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -1837,6 +1832,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
 
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -1854,13 +1858,6 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
-
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
-  dependencies:
-    fetch-blob "^3.1.2"
 
 fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
@@ -2810,26 +2807,12 @@ node-addon-api@^1.6.3:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
 node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-fetch@^3.2.10:
-  version "3.2.10"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.2.10.tgz#e8347f94b54ae18b57c9c049ef641cef398a85c8"
-  integrity sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==
-  dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
 
 node-stream-zip@^1.15.0:
   version "1.15.0"
@@ -4020,11 +4003,6 @@ verror@^1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
-
-web-streams-polyfill@^3.0.3:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
-  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,6 +342,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/semver-compare@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/semver-compare/-/semver-compare-1.0.1.tgz#17d1dc62c516c133ab01efb7803a537ee6eaf3d5"
+  integrity sha512-wx2LQVvKlEkhXp/HoKIZ/aSL+TvfJdKco8i0xJS3aR877mg4qBHzNT6+B5a61vewZHo79EdZavskGnRXEC2H6A==
+
 "@types/semver@^7.3.6":
   version "7.3.10"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.10.tgz#5f19ee40cbeff87d916eedc8c2bfe2305d957f73"


### PR DESCRIPTION
## Description

Check if the version is auto updatable if not then don't download it and send a notification to UI about a new manually downloadable update 

see UI changes  https://github.com/ente-io/bada-frame/pull/759

## Test Plan

- [x] happy case
- [x] check app not downgrading 
- [x] check key change prompts manual update  
- [x] check that `skip version` works
- [x] check update failure shows manual update dialog
- [x] on error and updated-download are non-overlapping events
- [x] update and restart works
- [x] store auto migration on schema change