### PR TITLE
attach userID to sentry crash report 

### DIFF
--- a/src/services/sentry.ts
+++ b/src/services/sentry.ts
@@ -16,6 +16,7 @@ export function initSentry(): void {
         release: RELEASE_VERSION,
         environment: isDev ? 'development' : 'production',
     });
+    Sentry.setUser({ id: getSentryUserID() });
 }
 
 export function logErrorSentry(


### PR DESCRIPTION
## Description

missed setting global sentry user, so that crash reports are user tagged



## Test Plan

tested with localll test-release
