### PR TITLE
add get app version api

### DIFF
--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -9,6 +9,15 @@ export const selectRootDirectory = async (): Promise<string> => {
     }
 };
 
+export const getAppVersion = async (): Promise<string> => {
+    try {
+        return await ipcRenderer.invoke('get-app-version');
+    } catch (e) {
+        logError(e, 'failed to get release version');
+        throw e;
+    }
+};
+
 export {
     logToDisk,
     openLogDirectory,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -44,6 +44,7 @@ import {
     logToDisk,
     openLogDirectory,
     getSentryUserID,
+    getAppVersion,
 } from './api/common';
 import { fixHotReloadNext12 } from './utils/preload';
 import { isFolder, getDirFiles } from './api/fs';
@@ -98,4 +99,5 @@ windowObject['ElectronAPIs'] = {
     updateAndRestart,
     skipAppVersion,
     getSentryUserID,
+    getAppVersion,
 };

--- a/src/services/appUpdater.ts
+++ b/src/services/appUpdater.ts
@@ -87,6 +87,10 @@ export function updateAndRestart() {
     autoUpdater.quitAndInstall();
 }
 
+export function getAppVersion() {
+    return `v${app.getVersion()}`;
+}
+
 export function skipAppVersion(version: string) {
     setSkipAppVersion(version);
 }

--- a/src/utils/ipcComms.ts
+++ b/src/utils/ipcComms.ts
@@ -15,7 +15,11 @@ import chokidar from 'chokidar';
 import path from 'path';
 import { getDirFilePaths } from '../services/fs';
 import { convertHEIC } from '../services/heicConvertor';
-import { skipAppVersion, updateAndRestart } from '../services/appUpdater';
+import {
+    getAppVersion,
+    skipAppVersion,
+    updateAndRestart,
+} from '../services/appUpdater';
 
 export default function setupIpcComs(
     tray: Tray,
@@ -116,5 +120,9 @@ export default function setupIpcComs(
     });
     ipcMain.handle('get-sentry-id', () => {
         return getSentryUserID();
+    });
+
+    ipcMain.handle('get-app-version', () => {
+        return getAppVersion();
     });
 }


### PR DESCRIPTION
## Description

add API to get the release app version 

for UI see https://github.com/ente-io/bada-frame/pull/767

## Test Plan

tested with test release 
