### PR TITLE
Fix ffmpeg static for zip upload

### DIFF
--- a/src/api/ffmpeg.ts
+++ b/src/api/ffmpeg.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron';
+import { existsSync } from 'fs';
 import { logError } from '../services/logging';
 import { ElectronFile } from '../types';
 
@@ -10,7 +11,7 @@ export async function runFFmpegCmd(
     let inputFilePath = null;
     let createdTempInputFile = null;
     try {
-        if (!inputFile.path) {
+        if (!existsSync(inputFile.path)) {
             const inputFileData = new Uint8Array(await inputFile.arrayBuffer());
             inputFilePath = await ipcRenderer.invoke(
                 'write-temp-file',


### PR DESCRIPTION
## Description

zip paths were not accessible to FFmpeg. 

fixed it by checking inputFile path is valid, else fallback to creating a temp copy for FFmpeg 

## Test Plan

tested locally 
