### PR TITLE
Fix cmd+w close window keyboard shortcut mac 

### DIFF
--- a/src/utils/menu.ts
+++ b/src/utils/menu.ts
@@ -201,6 +201,7 @@ export async function buildMenuBar(): Promise<Menu> {
         {
             label: 'Window',
             submenu: [
+                { role: 'close', label: 'Close' },
                 { role: 'minimize', label: 'Minimize' },
                 ...((isMac
                     ? [
@@ -209,9 +210,7 @@ export async function buildMenuBar(): Promise<Menu> {
                           { type: 'separator' },
                           { role: 'window', label: 'ente' },
                       ]
-                    : [
-                          { role: 'close', label: 'Close ente' },
-                      ]) as MenuItemConstructorOptions[]),
+                    : []) as MenuItemConstructorOptions[]),
             ],
         },
         {


### PR DESCRIPTION
## Description

add the missing close window on the mac window submenu. 

new menu 
<img width="368" alt="image" src="https://user-images.githubusercontent.com/46242073/203040584-0a70a180-221e-4caf-a458-5f9270c97ced.png">


## Test Plan

tested locally 
