### PR TITLE
Update gitignore to include .env and .electron-symbols/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ buildingSteps.md
 .DS_Store
 .idea/
 build/.DS_Store
+.env
+.electron-symbols/


### PR DESCRIPTION
## Description

The .electron-symbols folder is generated when uploading Electron symbols to our self hosted Sentry via `sentry-symbols.js`.

## Test Plan

None.